### PR TITLE
use AB::MB for configure_requires

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -67,7 +67,7 @@ my $builder = Alien::Base::ModuleBuild
            license              => 'perl',
            dist_author          => q{Salvador Fandiño <sfandino@yahoo.com>},
            dist_version_from    => 'lib/Alien/Libgpg_error.pm',
-           configure_requires   => { 'Alien::Base' => '0.024',
+           configure_requires   => { 'Alien::Base::ModuleBuild' => '0.024',
                                      'Module::Build' => '0.36' },
            build_requires       => { 'Test::More' => 0 },
            add_to_cleanup       => [ 'Alien-Libgpg_error-*' ],


### PR DESCRIPTION
This will future proof this module in the event that `Alien::Base::ModuleBuild` is spun off from the rest of `Alien::Base`.  For the rationale for this change, please see https://github.com/Perl5-Alien/Alien-Base/issues/157
